### PR TITLE
CASMPET-5936-1.3: BREAK/FIX: restore postgres from backup encountered errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,13 @@ FROM artifactory.algol60.net/docker.io/library/alpine AS base
 
 WORKDIR /usr/src/app
 
-RUN apk add --no-cache python3 postgresql-client postgresql-dev gcc python3-dev musl-dev && ln -sf python3 /usr/bin/python
+RUN apk add --no-cache python3 gcc python3-dev musl-dev && ln -sf python3 /usr/bin/python
+
+# To maintain psql v12 -- pin postgresql-client and postgresql-dev
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.12/main" >> /etc/apk/repositories
+RUN apk add 'postgresql-client=12.10-r0'
+RUN apk add 'postgresql-dev=12.10-r0'
+
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools
 


### PR DESCRIPTION
## Summary and Scope

Rebuild the cray-postgres-db-backup:0.2.3 image to use the latest Alpine (3.16) and also maintain psql v12.
This is needed to allow for cronjob based postgres backups to be restorable onto the existing psql v12 cluster.
The previous 0.2.0, 0.2.1 and 0.2.2 images all installed psql v14 which broke the postgres restore.

_Is this change is a backwards compatible bugfix.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves part 1 of [CASMPET-5936](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5936)
* Change will also be needed in `NA`
* Future work required 
** part2 is to release cray-postgres-db-backup:0.2.3
** part3 is to rebuild cray-service chart for csm 1.3 to set 0.2.3 as the default PostgresDbBackup.image.tag
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

vshasta

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

* Verified that the cray-postgres-db-backup test image installed the psql v12
```
C02YP47BLVCG:scripts kim.jensen$ docker run --rm -it artifactory.algol60.net/csm-docker/unstable/cray-postgres-db-backup:0.2.2-20220907172108_bf557e8 sh
...
/usr/src/app # psql --version
psql (PostgreSQL) 12.10
```

* Sec vulnerabilities - one High Vulnerability which cannot be resolved due to the psql v12 pinning
```
(venv) C02YP47BLVCG:postgres-db-backup kim.jensen$ snyk test --docker artifactory.algol60.net/csm-docker/unstable/cray-postgres-db-backup:0.2.2-20220907172108_bf557e8 --file=/Users/kim.jensen/github/postgres-db-backup/Dockerfile
...
Testing artifactory.algol60.net/csm-docker/unstable/cray-postgres-db-backup:0.2.2-20220907172108_bf557e8...

✗ High severity vulnerability found in openldap/libldap
  Description: SQL Injection
  Info: https://snyk.io/vuln/SNYK-ALPINE316-OPENLDAP-2863512
  Introduced through: openldap/libldap@2.4.58-r0, postgresql/postgresql-client@12.10-r0
  From: openldap/libldap@2.4.58-r0
  From: postgresql/postgresql-client@12.10-r0 > postgresql/libpq@12.10-r0 > openldap/libldap@2.4.58-r0
  Introduced by your base image (artifactory.algol60.net/docker.io/library/alpine)
  Fixed in: 2.6.2-r0
  
  Organization:      kim.jensenhpe.com
Package manager:   apk
Target file:       /Users/kim.jensen/github/postgres-db-backup/Dockerfile
Project name:      docker-image|artifactory.algol60.net/csm-docker/unstable/cray-postgres-db-backup
Docker image:      artifactory.algol60.net/csm-docker/unstable/cray-postgres-db-backup:0.2.2-20220907172108_bf557e8
Platform:          linux/amd64
Base image:        artifactory.algol60.net/docker.io/library/alpine
Licenses:          enabled

Tested 56 dependencies for known issues, found 1 issue.
```

* Postgres Backup/Restore of cray-keycloak
```
Installed vshasta with cray-keycloak chart with the test image
Backed up postgres using the cronjob
Restored postgres after the cray-keycloak chart was uninstall/reinstalled based on the System Recovery WIKI
```
- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

